### PR TITLE
Fix authentification process for botkit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ function getStorageObj(client, namespace) {
     return {
         get: function(id, cb) {
             client.hget(namespace, id, function(err, res) {
-                cb(err, res ? JSON.parse(res) : {});
+                cb(err, res ? JSON.parse(res) : null);
             });
         },
         save: function(object, cb) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -91,7 +91,7 @@ describe('Redis', function() {
 
                     redisClientMock.hget.should.be.calledWithMatch(hash, 'walterwhite');
                     JSON.parse.should.not.be.called;
-                    cb.should.be.calledWith(null, {});
+                    cb.should.be.calledWith(null, null);
                 });
 
                 it('should call the callback with an error if redis fails', function() {
@@ -103,7 +103,7 @@ describe('Redis', function() {
 
                     redisClientMock.hget.should.be.calledWithMatch(hash, 'walterwhite');
                     JSON.parse.should.not.be.called;
-                    cb.should.be.calledWith(err, {});
+                    cb.should.be.calledWith(err, null);
                 });
             });
 


### PR DESCRIPTION
Botkit assume that get function should return null, not empty object, if there is no data in the store.
Otherwise it is fail