### PR TITLE
Add method to remove from redis

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "istanbul": "^0.4.1",
+    "jscs": "^2.8.0",
     "mocha": "^2.3.4",
     "proxyquire": "^1.7.3",
     "should": "^8.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,9 @@ function getStorageObj(client, namespace) {
 
             client.hset(namespace, object.id, JSON.stringify(object), cb);
         },
+        remove: function(id, cb) {
+            client.hdel(namespace, [id], cb);
+        },
         all: function(cb, options) {
             client.hgetall(namespace, function(err, res) {
                 if (err) {

--- a/tests/index.js
+++ b/tests/index.js
@@ -14,7 +14,8 @@ describe('Redis', function() {
         redisClientMock = {
             hget: sinon.stub(),
             hset: sinon.stub(),
-            hgetall: sinon.stub()
+            hdel: sinon.stub(),
+            hgetall: sinon.stub(),
         };
 
         redisMock = {
@@ -142,6 +143,30 @@ describe('Redis', function() {
                     );
                 });
             });
+
+            describe('remove', function() {
+
+                beforeEach(function() {
+                    sinon.spy(JSON, 'stringify');
+                });
+
+                afterEach(function() {
+                    JSON.stringify.restore();
+                });
+
+                it('should remove from redis', function() {
+                    var id = 'heisenberg', cb = sinon.stub();
+
+                    storageInterface[method].remove(id, cb);
+
+                    redisClientMock.hdel.should.be.calledWith(
+                        defaultNamespace + ':' + method,
+                        ['heisenberg'],
+                        cb
+                    );
+                });
+            });
+
 
             describe('all', function() {
 


### PR DESCRIPTION
I added a new method to remove data from redis. My use case is when I try to connect to a team that has bad credentials, I'd like to remove that team so I don't try to connect again the next time my bot restarts. I think my test case could use some help though. I wasn't familiar with some of the concepts in there so I'd like to open this as a starting point in the conversation.